### PR TITLE
Change the stdout debug logging to be done only when the

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -42,6 +42,13 @@ So, if you share a logger object accross threads, please use ```__gshared```.
        Single-threaded: dub build --config=post-example
        Multi-threaded: dub build --config=post-mt-example
 
+## Debug logging:
+
+    Limited logging to stdout can be enabled by adding FluentLogger to debugVersions in your project's dub.json:
+```
+"debugVersions": ["FluentLogger"],
+```
+
 ## TODO
 
 * std.log support after Phobos accepts std.log

--- a/src/fluent/logger.d
+++ b/src/fluent/logger.d
@@ -44,7 +44,7 @@ private import std.datetime : Clock, SysTime;
 private import std.socket : getAddress, lastSocketError, ProtocolType, Socket,
                             SocketException, SocketShutdown, SocketType, TcpSocket;
 
-debug import std.stdio;  // TODO: replace with std.log
+debug(FluentLogger) import std.stdio;  // TODO: replace with std.log
 
 private import msgpack;
 
@@ -223,7 +223,7 @@ class FluentLogger : Logger
                         send(buffer_[]);
                         buffer_.length = 0;
                     } catch (const SocketException e) {
-                        debug { writeln("Failed to flush logs. ", buffer_.length, " bytes not sent."); }
+                        debug(FluentLogger) { writeln("FluentLogger: Failed to flush logs. ", buffer_.length, " bytes not sent."); }
                     }
                 }
 
@@ -293,7 +293,7 @@ class FluentLogger : Logger
                 errorNum_  = 0;
                 errorTime_ = SysTime.init;
 
-                debug { writeln("Connected to: host = ", config_.host, ", port = ", config_.port); }
+                debug(FluentLogger) { writeln("FluentLogger: Connected to: host = ", config_.host, ", port = ", config_.port); }
 
                 return;
             } catch (SocketException e) {
@@ -336,7 +336,7 @@ class FluentLogger : Logger
             throw new SocketException("Unable to send to socket. ", lastSocketError());
         }
 
-        debug { writeln("Sent: ", data.length, " bytes"); }
+        debug(FluentLogger) { writeln("FluentLogger: Sent ", data.length, " bytes"); }
     }
     
     /**


### PR DESCRIPTION
FluentLogger version has been specified.

This gives users better control over whether they want to see debug info. 
